### PR TITLE
Add BTC price scheduler

### DIFF
--- a/data_ingestion/fetcher.py
+++ b/data_ingestion/fetcher.py
@@ -1,0 +1,28 @@
+import requests
+import openpyxl
+from datetime import datetime
+from pathlib import Path
+
+EXCEL_FILE = Path("bitcoin_prices.xlsx")
+
+def obtener_precio_bitcoin():
+    url = "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd"
+    return requests.get(url, timeout=10).json()["bitcoin"]["usd"]
+
+def guardar_precio():
+    precio = obtener_precio_bitcoin()
+    ahora = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    if not EXCEL_FILE.exists():
+        wb = openpyxl.Workbook()
+        wb.active.append(["Fecha", "Precio USD"])
+        wb.save(EXCEL_FILE)
+
+    wb = openpyxl.load_workbook(EXCEL_FILE)
+    sheet = wb.active
+    sheet.append([ahora, precio])
+    wb.save(EXCEL_FILE)
+    print(f"[{ahora}] BTC: ${precio}")
+
+if __name__ == "__main__":
+    guardar_precio()

--- a/data_ingestion/scheduler.py
+++ b/data_ingestion/scheduler.py
@@ -1,0 +1,18 @@
+import schedule
+import time
+from fetcher import guardar_precio
+
+
+def job():
+    try:
+        guardar_precio()
+    except Exception as e:
+        print(f"Error al guardar el precio: {e}")
+
+
+if __name__ == "__main__":
+    schedule.every(10).minutes.do(job)
+    job()
+    while True:
+        schedule.run_pending()
+        time.sleep(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+openpyxl
+schedule


### PR DESCRIPTION
## Summary
- add `schedule` to requirements
- implement `data_ingestion/scheduler.py` to call `guardar_precio` every 10 minutes

## Testing
- `pip install -r requirements.txt`
- `python3 data_ingestion/scheduler.py` *(prints fetched price then waits)*

------
https://chatgpt.com/codex/tasks/task_e_6840c8bf2068832b944afca0e9da43c3