### PR TITLE
Add ensure_data wrapper and update grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,8 @@ Para experimentar con distintas estrategias y parámetros puedes ejecutar el gri
 ```bash
 python backtests/run_grid.py
 ```
+
+## Ejemplo de backtest con verificación de datos
+```bash
+python tools/ensure_data_and_run.py backtests.ema_s2f_backtest --save equity.png
+```

--- a/backtests/run_grid.py
+++ b/backtests/run_grid.py
@@ -1,10 +1,16 @@
 """Ejecuta una búsqueda de parámetros para estrategias."""
 
-import importlib
-import itertools
+import sys
 from pathlib import Path
 
-import pandas as pd
+sys.path.append(str(Path(__file__).resolve().parent.parent))  # noqa: E402
+
+import importlib  # noqa: E402
+import itertools  # noqa: E402
+
+import pandas as pd  # noqa: E402
+
+from tools.ensure_data_and_run import ensure_data  # noqa: E402
 
 EXCEL_FILE = Path("bitcoin_prices.xlsx")
 
@@ -47,11 +53,15 @@ def run_backtest(module_name: str, **params) -> tuple[float, float]:
 
     equity_series = pd.Series(equity_curve)
     returns = equity_series.pct_change().dropna()
-    sharpe = (returns.mean() / returns.std()) * (252**0.5) if not returns.empty else 0.0
+    annual_factor = 252**0.5
+    # fmt: off
+    sharpe = (returns.mean() / returns.std()) * annual_factor if not returns.empty else 0.0  # noqa: E501
+    # fmt: on
     return capital, sharpe
 
 
 def main():
+    ensure_data()
     grid = {
         "strategies.rsi_mean_reversion": {
             "rsi_period": [14, 21],

--- a/tools/ensure_data_and_run.py
+++ b/tools/ensure_data_and_run.py
@@ -1,0 +1,42 @@
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+EXCEL_FILE = Path("bitcoin_prices.xlsx")
+
+
+def ensure_data() -> None:
+    """Descarga datos historicos si el archivo no existe."""
+    if not EXCEL_FILE.exists():
+        subprocess.run(
+            [sys.executable, "-m", "data_ingestion.historic_fetcher"],
+            check=True,
+        )
+
+
+def main() -> None:
+    # fmt: off
+    parser = argparse.ArgumentParser(
+        description="Verifica datos y ejecuta un modulo"
+    )
+    # fmt: on
+    parser.add_argument(
+        "module",
+        help="Modulo Python a ejecutar (formato paquete.modulo)",
+    )
+    parser.add_argument(
+        "module_args",
+        nargs=argparse.REMAINDER,
+        help="Argumentos para el modulo",
+    )
+    args = parser.parse_args()
+
+    ensure_data()
+
+    cmd = [sys.executable, "-m", args.module] + args.module_args
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add ensure_data_and_run wrapper script to fetch data if missing
- update README with example usage
- call `ensure_data()` in `run_grid.py`

## Testing
- `python tools/ensure_data_and_run.py backtests.ema_s2f_backtest --save equity.png`
- `python backtests/run_grid.py | head -n 5`
- `flake8 tools/ensure_data_and_run.py backtests/run_grid.py`

------
https://chatgpt.com/codex/tasks/task_e_684110960d2c832b94a5548aa9a9a50c