### PR TITLE
Add automatic setup and backtest script

### DIFF
--- a/setup_and_run.py
+++ b/setup_and_run.py
@@ -37,8 +37,9 @@ def verificar_archivo_excel(path: Path) -> pd.DataFrame | None:
     obligatorias = {"Fecha", "Precio USD"}
     if not obligatorias.issubset(columnas):
         faltantes = obligatorias - columnas
+        faltantes_str = ", ".join(faltantes)
         print(
-            f"[ERROR] El archivo no contiene las columnas obligatorias: {', '.join(faltantes)}"
+            f"[ERROR] El archivo no contiene las columnas obligatorias: {faltantes_str}"
         )
         return None
 


### PR DESCRIPTION
## Summary
- rewrite `setup_and_run.py` to perform automatic checks and run a default RSI backtest
  - verifica que `bitcoin_prices.xlsx` exista y contenga las columnas necesarias
  - verifica la presencia de carpetas `strategies/` y `backtests/`
  - instala automáticamente `pandas`, `matplotlib` y `openpyxl`
  - ajusta `sys.path` cuando no se puede importar `strategies`
  - ejecuta la estrategia `rsi_mean_reversion` con parámetros predeterminados
  - calcula métricas y guarda la curva de capital como `equity_curve.png`

## Testing
- `black setup_and_run.py -q`
- `isort setup_and_run.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6841305eb758832b98d6ff1d33af51af