### PR TITLE
Add SQLAlchemy data ingestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,4 @@ cython_debug/
 .cursorindexingignore
 bitcoin_prices.xlsx
 
+database.db

--- a/data_ingestion/historic_fetcher.py
+++ b/data_ingestion/historic_fetcher.py
@@ -1,40 +1,67 @@
+"""Download historical prices and store them in SQLite."""
+
+from __future__ import annotations
+
 from datetime import datetime, timezone
+from typing import Any
 
 import requests
+from sqlalchemy.exc import SQLAlchemyError
 
-from analytics.s2f import calcular_desviacion, obtener_valor_s2f
-from storage.repository import EXCEL_FILE, guardar_registro, inicializar_bd
+from models import PriceHistory, SessionLocal, init_db
 
 
-def fetch_historical_prices():
-    """Obtiene precios historicos diarios de los ultimos 90 dias."""
-    url = "https://api.coingecko.com/api/v3/coins/bitcoin/market_chart"
+def ingest_price_history(coin_id: str) -> None:
+    """Download last 90 days of price data for ``coin_id`` and store it.
+
+    Existing records for the same coin and date are not duplicated.
+    """
+
+    init_db()
+    session = SessionLocal()
+
+    url = f"https://api.coingecko.com/api/v3/coins/{coin_id}/market_chart"
     params = {"vs_currency": "usd", "days": "90", "interval": "daily"}
     try:
         resp = requests.get(url, params=params, timeout=10)
         resp.raise_for_status()
-        data = resp.json()
-        return data.get("prices", [])
-    except Exception as e:
-        print(f"[ADVERTENCIA] Error al obtener datos historicos: {e}")
-        return []
+        data: dict[str, Any] = resp.json()
+    except Exception as e:  # noqa: BLE001
+        print(f"[ADVERTENCIA] Error al obtener datos de {coin_id}: {e}")
+        session.close()
+        return
 
+    prices = data.get("prices", [])
+    prev_price = None
+    for ts, price in prices:
+        date_val = datetime.fromtimestamp(ts / 1000, tz=timezone.utc).date()
+        if (
+            session.query(PriceHistory)
+            .filter_by(coin_id=coin_id, date=date_val)
+            .first()
+        ):
+            prev_price = price
+            continue
+        pct_change = None
+        if prev_price is not None and prev_price != 0:
+            pct_change = (price - prev_price) / prev_price * 100
+        record = PriceHistory(
+            coin_id=coin_id,
+            date=date_val,
+            price_usd=price,
+            pct_change_24h=pct_change,
+        )
+        session.add(record)
+        prev_price = price
 
-def main():
-    # Reiniciar el archivo para esta descarga
-    if EXCEL_FILE.exists():
-        EXCEL_FILE.unlink()
-    inicializar_bd()
-
-    registros = fetch_historical_prices()
-    for ts, precio in registros:
-        fecha = datetime.fromtimestamp(ts / 1000, tz=timezone.utc).strftime("%Y-%m-%d")
-        s2f = obtener_valor_s2f(fecha)
-        desviacion = calcular_desviacion(precio, s2f) if s2f is not None else 0.0
-        guardar_registro(fecha, precio, desviacion)
-
-    print(f"Datos historicos guardados en {EXCEL_FILE}")
+    try:
+        session.commit()
+    except SQLAlchemyError as e:
+        session.rollback()
+        print(f"[ADVERTENCIA] Error al guardar en la base de datos: {e}")
+    finally:
+        session.close()
 
 
 if __name__ == "__main__":
-    main()
+    ingest_price_history("bitcoin")

--- a/models.py
+++ b/models.py
@@ -1,0 +1,37 @@
+from sqlalchemy import (
+    Column,
+    Date,
+    Float,
+    Integer,
+    String,
+    UniqueConstraint,
+    create_engine,
+)
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = "sqlite:///database.db"
+
+engine = create_engine(DATABASE_URL, echo=False)
+SessionLocal = sessionmaker(bind=engine)
+
+Base = declarative_base()
+
+
+class PriceHistory(Base):
+    __tablename__ = "price_history"
+
+    id = Column(Integer, primary_key=True)
+    coin_id = Column(String, nullable=False)
+    date = Column(Date, nullable=False)
+    price_usd = Column(Float, nullable=False)
+    price_clp = Column(Float)
+    pct_change_24h = Column(Float)
+    s2f_deviation = Column(Float)
+
+    _coin_date_uc = UniqueConstraint("coin_id", "date", name="uix_coin_date")
+    __table_args__ = (_coin_date_uc,)
+
+
+def init_db() -> None:
+    """Create tables if they do not exist."""
+    Base.metadata.create_all(engine)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ matplotlib
 black
 isort
 flake8
+SQLAlchemy

--- a/run_ingestion.py
+++ b/run_ingestion.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+"""Run a sample ingestion for Bitcoin."""
+from data_ingestion.historic_fetcher import ingest_price_history
+
+
+def main() -> None:
+    ingest_price_history("bitcoin")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `PriceHistory` SQLAlchemy model and DB initialization
- rewrite historical fetcher to store data in SQLite
- add script to run ingestion for Bitcoin
- include SQLAlchemy dependency and ignore generated DB file

## Testing
- `black models.py data_ingestion/historic_fetcher.py run_ingestion.py`
- `flake8 models.py data_ingestion/historic_fetcher.py run_ingestion.py`
- `python run_ingestion.py`
- `sqlite3 database.db "SELECT COUNT(*) FROM price_history;"`

------
https://chatgpt.com/codex/tasks/task_e_684239dfd3d0832b8c3f7a4ef325e96a