### PR TITLE
Support multiple fiat currencies

### DIFF
--- a/data_ingestion/historic_fetcher.py
+++ b/data_ingestion/historic_fetcher.py
@@ -2,13 +2,48 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any
+from datetime import date, datetime, timezone
+from typing import Any, Iterable
 
 import requests
 from sqlalchemy.exc import SQLAlchemyError
 
 from models import PriceHistory, SessionLocal, init_db
+
+FX_URL = "https://api.exchangerate.host/timeseries"
+
+
+def fetch_fx_rates(dates: Iterable[date]) -> dict[date, dict[str, float]]:
+    """Return USD to CLP/EUR rates for the given dates."""
+
+    if not dates:
+        return {}
+    start = min(dates)
+    end = max(dates)
+    params = {
+        "start_date": start.isoformat(),
+        "end_date": end.isoformat(),
+        "base": "USD",
+        "symbols": "CLP,EUR",
+    }
+    try:
+        resp = requests.get(FX_URL, params=params, timeout=10)
+        resp.raise_for_status()
+        data: dict[str, Any] = resp.json()
+    except Exception as e:  # noqa: BLE001
+        print(f"[ADVERTENCIA] Error al obtener tasas de cambio: {e}")
+        return {}
+
+    results: dict[date, dict[str, float]] = {}
+    for key, rates in data.get("rates", {}).items():
+        try:
+            dt = date.fromisoformat(key)
+        except ValueError:
+            continue
+        clp = rates.get("CLP")
+        eur = rates.get("EUR")
+        results[dt] = {"CLP": clp, "EUR": eur}
+    return results
 
 
 def ingest_price_history(coin_id: str) -> None:
@@ -32,6 +67,9 @@ def ingest_price_history(coin_id: str) -> None:
         return
 
     prices = data.get("prices", [])
+    dates = [datetime.fromtimestamp(ts / 1000, tz=timezone.utc).date() for ts, _ in prices]
+    fx_rates = fetch_fx_rates(dates)
+
     prev_price = None
     for ts, price in prices:
         date_val = datetime.fromtimestamp(ts / 1000, tz=timezone.utc).date()
@@ -45,10 +83,15 @@ def ingest_price_history(coin_id: str) -> None:
         pct_change = None
         if prev_price is not None and prev_price != 0:
             pct_change = (price - prev_price) / prev_price * 100
+        rate = fx_rates.get(date_val, {})
+        price_clp = price * rate.get("CLP") if rate.get("CLP") is not None else None
+        price_eur = price * rate.get("EUR") if rate.get("EUR") is not None else None
         record = PriceHistory(
             coin_id=coin_id,
             date=date_val,
             price_usd=price,
+            price_clp=price_clp,
+            price_eur=price_eur,
             pct_change_24h=pct_change,
         )
         session.add(record)

--- a/models.py
+++ b/models.py
@@ -25,6 +25,7 @@ class PriceHistory(Base):
     date = Column(Date, nullable=False)
     price_usd = Column(Float, nullable=False)
     price_clp = Column(Float)
+    price_eur = Column(Float)
     pct_change_24h = Column(Float)
     s2f_deviation = Column(Float)
 

--- a/tests/test_historic_fetcher.py
+++ b/tests/test_historic_fetcher.py
@@ -1,0 +1,75 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+import pytest
+import requests
+
+import models
+from data_ingestion import historic_fetcher
+from data_ingestion.historic_fetcher import ingest_price_history
+
+
+class FakeResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+def fake_get_factory():
+    coingecko_data = {
+        "prices": [
+            [1704067200000, 30000.0],
+            [1704153600000, 31000.0],
+        ]
+    }
+    fx_data = {
+        "rates": {
+            "2024-01-01": {"CLP": 900.0, "EUR": 0.9},
+            "2024-01-02": {"CLP": 905.0, "EUR": 0.91},
+        }
+    }
+
+    def fake_get(url, params=None, timeout=10):
+        if "coingecko" in url:
+            return FakeResponse(coingecko_data)
+        if "exchangerate.host" in url:
+            return FakeResponse(fx_data)
+        raise RuntimeError("Unexpected URL")
+
+    return fake_get
+
+
+@pytest.fixture()
+def db(monkeypatch):
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    models.init_db()
+    monkeypatch.setattr(historic_fetcher, "SessionLocal", models.SessionLocal)
+    monkeypatch.setattr(historic_fetcher, "init_db", models.init_db)
+    monkeypatch.setattr(requests, "get", fake_get_factory())
+    yield
+
+
+def test_ingestion_with_fx(db):
+    ingest_price_history("bitcoin")
+    # running again should not duplicate
+    ingest_price_history("bitcoin")
+
+    with models.SessionLocal() as session:
+        rows = session.query(models.PriceHistory).order_by(models.PriceHistory.date).all()
+        assert len(rows) == 2
+        assert rows[0].price_clp == pytest.approx(30000.0 * 900.0)
+        assert rows[0].price_eur == pytest.approx(30000.0 * 0.9)
+        assert rows[1].price_clp == pytest.approx(31000.0 * 905.0)
+        assert rows[1].price_eur == pytest.approx(31000.0 * 0.91)
+


### PR DESCRIPTION
## Summary
- track Bitcoin prices in USD, CLP and EUR
- convert via exchangerate.host in ingestion
- test ingestion with mocked API responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842474b1120832b8fa933e7fbb4f62d