### PR TITLE
Implement performance comparison vs hold

### DIFF
--- a/analytics/performance.py
+++ b/analytics/performance.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy.orm import sessionmaker
+
+from storage.database import get_price_on, init_db, init_engine
+
+
+def comparar_vs_hold(
+    coin_id: str,
+    fecha_inicio: str,
+    fecha_fin: str,
+    resultado_backtest: dict[str, Any],
+    db_url: str = "sqlite:///prices.sqlite",
+) -> dict[str, Any]:
+    """Compara el retorno de una estrategia con un enfoque buy & hold."""
+
+    start = datetime.fromisoformat(fecha_inicio).date()
+    end = datetime.fromisoformat(fecha_fin).date()
+
+    engine = init_engine(db_url)
+    init_db(engine)
+    Session = sessionmaker(bind=engine)
+
+    with Session() as session:
+        start_price = get_price_on(session, coin_id, start)
+        end_price = get_price_on(session, coin_id, end)
+
+    if start_price is None or end_price is None:
+        raise ValueError("Faltan precios en la base de datos")
+
+    retorno_hold = end_price / start_price - 1
+
+    curva = resultado_backtest.get("equity_curve")
+    if not curva:
+        raise ValueError("resultado_backtest debe incluir 'equity_curve'")
+    retorno_estrategia = curva[-1] / curva[0] - 1
+
+    if abs(retorno_estrategia - retorno_hold) < 1e-9:
+        comparacion = "igual"
+    elif retorno_estrategia > retorno_hold:
+        comparacion = "mejor"
+    else:
+        comparacion = "peor"
+
+    return {
+        "estrategia_vs_hold": comparacion,
+        "retorno_estrategia": retorno_estrategia,
+        "retorno_hold": retorno_hold,
+    }

--- a/tests/test_compare_hold.py
+++ b/tests/test_compare_hold.py
@@ -1,0 +1,86 @@
+import os
+import sys
+import tempfile
+from datetime import date
+from decimal import Decimal
+from typing import Dict
+
+BASE_DIR = os.path.dirname(__file__)
+sys.path.append(os.path.abspath(os.path.join(BASE_DIR, "..")))  # noqa: E402
+
+import pytest  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+from analytics.performance import comparar_vs_hold  # noqa: E402
+from storage.database import ingest_price_history  # noqa: E402
+from storage.database import init_db, init_engine  # noqa: E402
+
+
+def _rates(_: date) -> Dict[str, Decimal]:
+    return {"CLP": Decimal("900"), "EUR": Decimal("0.9")}
+
+
+def _prepare_db() -> tuple[str, sessionmaker]:
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    url = f"sqlite:///{tmp.name}"
+    engine = init_engine(url)
+    init_db(engine)
+    return url, sessionmaker(bind=engine)
+
+
+def test_comparar_vs_hold_mejor():
+    url, Session = _prepare_db()
+    with Session() as session:
+        ingest_price_history(
+            session,
+            "btc",
+            date(2024, 1, 1),
+            100.0,
+            rates_fn=_rates,
+        )
+        ingest_price_history(
+            session,
+            "btc",
+            date(2024, 1, 2),
+            120.0,
+            rates_fn=_rates,
+        )
+
+    result = comparar_vs_hold(
+        "btc",
+        "2024-01-01",
+        "2024-01-02",
+        {"equity_curve": [1.0, 1.3]},
+        db_url=url,
+    )
+    assert result["estrategia_vs_hold"] == "mejor"
+    assert result["retorno_hold"] == pytest.approx(0.2)
+    assert result["retorno_estrategia"] == pytest.approx(0.3)
+
+
+def test_comparar_vs_hold_peor():
+    url, Session = _prepare_db()
+    with Session() as session:
+        ingest_price_history(
+            session,
+            "btc",
+            date(2024, 1, 1),
+            100.0,
+            rates_fn=_rates,
+        )
+        ingest_price_history(
+            session,
+            "btc",
+            date(2024, 1, 2),
+            110.0,
+            rates_fn=_rates,
+        )
+
+    result = comparar_vs_hold(
+        "btc",
+        "2024-01-01",
+        "2024-01-02",
+        {"equity_curve": [1.0, 1.05]},
+        db_url=url,
+    )
+    assert result["estrategia_vs_hold"] == "peor"


### PR DESCRIPTION
## Summary
- add `comparar_vs_hold` helper in analytics
- test performance comparison with a temporary DB

## Testing
- `flake8 analytics/performance.py tests/test_compare_hold.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684255504488832bb7cf5fc242b7e152