### PR TITLE
Implement comparar_vs_hold utility and update tests

### DIFF
--- a/tests/test_compare_hold.py
+++ b/tests/test_compare_hold.py
@@ -50,10 +50,10 @@ def test_comparar_vs_hold_mejor():
         "btc",
         "2024-01-01",
         "2024-01-02",
-        {"equity_curve": [1.0, 1.3]},
+        [1.0, 1.3],
         db_url=url,
     )
-    assert result["estrategia_vs_hold"] == "mejor"
+    assert result["comparacion"] == "mejor"
     assert result["retorno_hold"] == pytest.approx(0.2)
     assert result["retorno_estrategia"] == pytest.approx(0.3)
 
@@ -80,7 +80,7 @@ def test_comparar_vs_hold_peor():
         "btc",
         "2024-01-01",
         "2024-01-02",
-        {"equity_curve": [1.0, 1.05]},
+        [1.0, 1.05],
         db_url=url,
     )
-    assert result["estrategia_vs_hold"] == "peor"
+    assert result["comparacion"] == "peor"


### PR DESCRIPTION
## Summary
- expand comparar_vs_hold to accept equity curve directly
- return `comparacion` field to indicate performance vs buy & hold
- update unit tests for new behaviour

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68425a2ca270832b833554fa8d6305d1