### PR TITLE
Implement portfolio evaluation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,28 @@ distintas estrategias sobre un monto inicial. El formulario envía los datos al
 endpoint `/api/portfolio/eval` y muestra el retorno de la estrategia comparado
 con mantener la posición (hold).
 
+El endpoint acepta peticiones `POST` con el siguiente cuerpo JSON:
+
+```json
+{
+  "portfolio": [
+    {"coin_id": "bitcoin", "amount": 0.05, "buy_date": "2023-10-01"}
+  ],
+  "strategy": "ema_s2f"
+}
+```
+
+La respuesta indica el valor actual del portafolio y si la estrategia supera al
+`buy & hold`:
+
+```json
+{
+  "total_value_now": 1234.5,
+  "estrategia_vs_hold": "mejor",
+  "comentario": "Tu estrategia supera al hold en un 12%"
+}
+```
+
 ## Dependencias
 
 Las dependencias necesarias se detallan en [requirements.txt](requirements.txt):

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -26,3 +26,20 @@ class BacktestResult(BaseModel):
     cagr: float
     sharpe: float
     equity_curve: list[float]
+
+
+class PortfolioItem(BaseModel):
+    coin_id: str
+    amount: float
+    buy_date: date
+
+
+class PortfolioEvalRequest(BaseModel):
+    portfolio: list[PortfolioItem]
+    strategy: str
+
+
+class PortfolioEvalResponse(BaseModel):
+    total_value_now: float
+    estrategia_vs_hold: str
+    comentario: str

--- a/backtests/ema_s2f_backtest.py
+++ b/backtests/ema_s2f_backtest.py
@@ -8,10 +8,14 @@ from storage.models import get_price_history_df
 from strategies.ema_s2f import evaluar_estrategia
 
 
-def run_backtest(coin_id: str, initial_capital: float = 10000.0) -> dict:
+def run_backtest(
+    coin_id: str, initial_capital: float = 10000.0, start_date: str | None = None
+) -> dict:
     """Run the EMA S2F strategy and return key metrics."""
 
     df = get_price_history_df(coin_id)
+    if start_date is not None:
+        df = df[df["Fecha"] >= start_date].reset_index(drop=True)
     required_cols = {"Fecha", "Precio USD", "Desviación S2F %"}
     if not required_cols.issubset(df.columns):
         msg = "Datos insuficientes para el backtest"


### PR DESCRIPTION
## Summary
- extend backtest helper to accept optional start date
- add request/response models for portfolio evaluation
- create `/api/portfolio/eval` endpoint
- document new endpoint in README

## Testing
- `flake8 --max-line-length=88 --extend-ignore=E203,W503`
- `pytest -q`
- `PYTHONPATH=. python backtests/ema_s2f_backtest.py` *(fails: sqlite3.OperationalError: no such table: price_history)*

------
https://chatgpt.com/codex/tasks/task_e_68425d09d77c832bb63307ec9f45f27b