### PR TITLE
Add EvaluationHistory React component

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ La respuesta indica el valor actual del portafolio y si la estrategia supera al
 }
 ```
 
+Además existe el componente `EvaluationHistory` (ver
+`frontend/EvaluationHistory.jsx`) que consulta el endpoint `/api/evaluations` y
+muestra en una tabla el historial de evaluaciones con fecha, moneda,
+estrategia y el diferencial de retorno frente a un enfoque de holdear. Las
+filas pueden ordenarse por fecha o `coin_id` y al hacer clic se despliegan los
+detalles completos de la evaluación.
+
 ## Dependencias
 
 Las dependencias necesarias se detallan en [requirements.txt](requirements.txt):

--- a/frontend/EvaluationHistory.jsx
+++ b/frontend/EvaluationHistory.jsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react";
+
+export default function EvaluationHistory() {
+  const [evaluations, setEvaluations] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [sortField, setSortField] = useState("date");
+  const [sortDir, setSortDir] = useState("desc");
+  const [expandedId, setExpandedId] = useState(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      setLoading(true);
+      setError(null);
+      try {
+        const resp = await fetch("/api/evaluations");
+        if (!resp.ok) {
+          throw new Error("Failed to fetch evaluations");
+        }
+        const data = await resp.json();
+        setEvaluations(data);
+      } catch (err) {
+        setError(err.message);
+        setEvaluations([]);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, []);
+
+  const sorted = [...evaluations].sort((a, b) => {
+    let res = 0;
+    if (sortField === "date") {
+      res = new Date(a.date) - new Date(b.date);
+    } else if (sortField === "coin_id") {
+      res = a.coin_id.localeCompare(b.coin_id);
+    }
+    return sortDir === "asc" ? res : -res;
+  });
+
+  const toggleSort = (field) => {
+    if (field === sortField) {
+      setSortDir(sortDir === "asc" ? "desc" : "asc");
+    } else {
+      setSortField(field);
+      setSortDir("asc");
+    }
+  };
+
+  return (
+    <div className="p-4">
+      {error && <div className="text-red-600 mb-2">{error}</div>}
+      {loading ? (
+        <div>Loading...</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full border-collapse text-sm">
+            <thead className="bg-gray-200">
+              <tr>
+                <th
+                  className="p-2 border-b cursor-pointer text-left"
+                  onClick={() => toggleSort("date")}
+                >
+                  Fecha
+                </th>
+                <th
+                  className="p-2 border-b cursor-pointer text-left"
+                  onClick={() => toggleSort("coin_id")}
+                >
+                  Coin
+                </th>
+                <th className="p-2 border-b text-left">Estrategia</th>
+                <th className="p-2 border-b text-right">Retorno vs Hold</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((ev, idx) => {
+                const diff = (ev.return_strategy - ev.return_hold) * 100;
+                const isExpanded = expandedId === idx;
+                return (
+                  <>
+                    <tr
+                      key={idx}
+                      className="odd:bg-white even:bg-gray-50 hover:bg-gray-100 cursor-pointer"
+                      onClick={() =>
+                        setExpandedId(isExpanded ? null : idx)
+                      }
+                    >
+                      <td className="p-2 border-b">{ev.date}</td>
+                      <td className="p-2 border-b">{ev.coin_id}</td>
+                      <td className="p-2 border-b">{ev.strategy}</td>
+                      <td className="p-2 border-b text-right">
+                        {diff.toFixed(2)}%
+                      </td>
+                    </tr>
+                    {isExpanded && (
+                      <tr className="bg-gray-50 text-xs" key={`${idx}-details`}>
+                        <td colSpan={4} className="p-2 border-b">
+                          <pre className="whitespace-pre-wrap">
+                            {JSON.stringify(ev, null, 2)}
+                          </pre>
+                        </td>
+                      </tr>
+                    )}
+                  </>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new React component EvaluationHistory with sortable table
- document the new component in README

## Testing
- `black . --check`
- `isort --check-only .`
- `flake8 --max-line-length=88 --extend-ignore=E203,W503`
- `pytest -q`
- `python backtests/ema_s2f_backtest.py` *(fails: no such table: price_history)*

------
https://chatgpt.com/codex/tasks/task_e_68425f7d848c832b88145c451bcbadd8