### PR TITLE
Enable configurable DB URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=sqlite:///./data/database.db

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ almacenados en una base de datos SQLite. Para lanzarlo ejecuta:
 uvicorn api.main:app --reload
 ```
 
+La ruta de la base de datos puede configurarse con la variable de entorno
+`DATABASE_URL` (por defecto `sqlite:///./data/database.db`).
+⚙️ Crea un archivo `.env` con dicha variable. Puedes basarte en
+`.env.example`.
+
 Luego visita `http://localhost:8000/api/prices/{coin_id}` para obtener el
 historial diario en formato JSON.
 

--- a/analytics/performance.py
+++ b/analytics/performance.py
@@ -5,6 +5,7 @@ from typing import Any, List
 
 from sqlalchemy.orm import sessionmaker
 
+from config import DATABASE_URL
 from storage.database import get_price_on, init_db, init_engine
 
 
@@ -13,7 +14,7 @@ def comparar_vs_hold(
     fecha_inicio: str,
     fecha_fin: str,
     equity_curve: List[float],
-    db_url: str = "sqlite:///prices.sqlite",
+    db_url: str = DATABASE_URL,
 ) -> dict[str, Any]:
     """Compara el rendimiento de una estrategia con la estrategia de buy & hold.
 

--- a/api/database.py
+++ b/api/database.py
@@ -1,12 +1,9 @@
-from pathlib import Path
-
 from sqlalchemy import create_engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
-DATABASE_FILE = Path("prices.db")
-engine = create_engine(
-    f"sqlite:///{DATABASE_FILE}", connect_args={"check_same_thread": False}
-)
+from config import DATABASE_URL
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 
 

--- a/api/routes/core.py
+++ b/api/routes/core.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from analytics.performance import comparar_vs_hold
 from analytics.portfolio import analizar_portafolio
 from backtests.ema_s2f_backtest import run_backtest
+from config import DATABASE_URL
 from storage.database import get_price_on, init_db, init_engine
 
 from ..database import Base, SessionLocal, engine, get_db
@@ -91,7 +92,7 @@ async def eval_portfolio(request: PortfolioEvalRequest) -> PortfolioEvalResponse
 
     loop = asyncio.get_running_loop()
 
-    engine = init_engine("sqlite:///prices.sqlite")
+    engine = init_engine(DATABASE_URL)
     init_db(engine)
     Session = sessionmaker(bind=engine)
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,3 @@
+import os
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./data/database.db")

--- a/models.py
+++ b/models.py
@@ -9,7 +9,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import declarative_base, sessionmaker
 
-DATABASE_URL = "sqlite:///database.db"
+from config import DATABASE_URL
 
 engine = create_engine(DATABASE_URL, echo=False)
 SessionLocal = sessionmaker(bind=engine)

--- a/services/evaluation.py
+++ b/services/evaluation.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import sessionmaker
 
 from analytics.performance import comparar_vs_hold
 from backtests.ema_s2f_backtest import run_backtest
+from config import DATABASE_URL
 from storage.database import get_price_on, init_db, init_engine
 
 
@@ -19,7 +20,7 @@ def evaluate_request(input_data: Dict[str, Any]) -> Dict[str, Any]:
     if not portfolio:
         raise ValueError("Portfolio cannot be empty")
 
-    engine = init_engine("sqlite:///prices.sqlite")
+    engine = init_engine(DATABASE_URL)
     init_db(engine)
     Session = sessionmaker(bind=engine)
 

--- a/storage/models.py
+++ b/storage/models.py
@@ -1,11 +1,10 @@
-from pathlib import Path
-
 import pandas as pd
 from sqlalchemy import Column, Float, Integer, String, create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 
-DB_FILE = Path("prices.sqlite")
-engine = create_engine(f"sqlite:///{DB_FILE}")
+from config import DATABASE_URL
+
+engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(bind=engine)
 Base = declarative_base()
 


### PR DESCRIPTION
## Summary
- make database URL configurable via `DATABASE_URL`
- update persistence modules to use the shared setting
- document `DATABASE_URL` in README and provide `.env.example`

## Testing
- `flake8 --max-line-length=88 --extend-ignore=E203,W503`
- `black . --line-length 88`
- `isort . --profile black`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68426e6fd198832b84a6b191a20b73ba