### PR TITLE
Add Docker setup for API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 8000
+
+CMD mkdir -p /data && uvicorn api.main:app --host 0.0.0.0 --port 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+services:
+  api:
+    build: .
+    env_file: .env
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./data:/data
+    command: uvicorn api.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- add Dockerfile for running FastAPI with Uvicorn
- provide docker-compose.yml to run the API with a volume and env file

## Testing
- `pytest -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_68427dbf8f24832bb2a14fad0d8d1b96