### PR TITLE
Add pre-commit and contribution docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Descripción
+
+Breve explicación de los cambios propuestos.
+
+## Checklist
+- [ ] He corrido `pre-commit run --all-files` o `make style`.
+- [ ] He actualizado la documentación si es necesario.
+
+> Antes de solicitar revisión, ejecuta `pre-commit run --all-files` o `make style`.
+> Si el CI falla por estilo, corrige los imports con `isort .`.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/PyCQA/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.2.0
+    hooks:
+      - id: flake8

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: hooks style
+
+hooks:
+	pre-commit install
+
+style:
+	pre-commit run --all-files

--- a/README.md
+++ b/README.md
@@ -122,6 +122,32 @@ Para experimentar con distintas estrategias y parámetros puedes ejecutar el gri
 python backtests/run_grid.py
 ```
 
+### Hooks de pre-commit
+
+1. Instala dependencias de desarrollo  
+   ```bash
+   pip install -r requirements-dev.txt
+   ```
+
+2. Activa los hooks
+
+   ```bash
+   pre-commit install
+   ```
+
+Para formatear todo el proyecto de golpe:
+
+```bash
+pre-commit run --all-files
+```
+
+También puedes instalarlos con Make:
+
+```make
+make hooks
+```
+
+
 ## Ejemplo de backtest con verificación de datos
 
 ```bash

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pre-commit==3.7.0
+black==25.1.0
+isort==6.0.1
+flake8==7.2.0


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` with Black, isort and flake8
- document hook installation in `README.md`
- provide a Makefile with `hooks` and `style` targets
- add development requirements and PR template

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6845c2c34984832ba15a406e18deb13b