### PR TITLE
Update backtest runner periods and results path

### DIFF
--- a/backtests/multi_period_backtest_runner.py
+++ b/backtests/multi_period_backtest_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Run monthly injection backtest over multiple periods and compare with DCA."""
 
 import argparse
+import os
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
@@ -19,8 +20,10 @@ from monthly_injection_runner import (  # noqa: E402
 )
 
 DEFAULT_PERIODS: List[Tuple[str, str]] = [
+    ("2017-01-01", "2017-12-31"),
     ("2017-01-01", "2018-12-31"),
     ("2019-01-01", "2020-12-31"),
+    ("2020-03-01", "2021-03-31"),
     ("2021-01-01", "2022-12-31"),
     ("2023-01-01", "2024-06-01"),
     ("2017-01-01", "2024-06-01"),
@@ -124,7 +127,9 @@ def main() -> None:
     if not table.empty:
         print(table.to_string(index=False))
         if args.csv:
-            table.to_csv(args.csv, index=False)
+            csv_path = Path("results") / args.csv
+            os.makedirs(csv_path.parent, exist_ok=True)
+            table.to_csv(csv_path, index=False)
         if args.json:
             table.to_json(args.json, orient="records", indent=2)
 

--- a/docs/monthly_backtest_guide.md
+++ b/docs/monthly_backtest_guide.md
@@ -53,4 +53,7 @@ python -m backtests.multi_period_backtest_runner \
     --csv resultados.csv
 ```
 
+El archivo se guardará automáticamente en la carpeta `results/` como
+`results/resultados.csv`.
+
 Si no indicas periodos, se probarán cinco rangos predefinidos que cubren distintos ciclos de mercado. Puedes personalizar los periodos pasando pares de fechas (`inicio fin`) al argumento `--periods`.


### PR DESCRIPTION
## Summary
- include 2017-only and 2020-2021 periods in default list
- save CSV outputs inside `results/` ensuring the folder exists
- document new path for results file

## Testing
- `pre-commit run --files backtests/multi_period_backtest_runner.py docs/monthly_backtest_guide.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68489ccf0470832b8c58ed756fa0026b