### PR TITLE
Mejoras en multi-period backtest

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,13 @@ Estrategia de acumulación de Bitcoin que utiliza indicadores técnicos para ide
   python backtests/run_grid.py
   python backtests/ema_s2f_backtest.py
   ```
-- Los resultados se guardan en `results/` y los gráficos como `equity.png` pueden consultarse para interpretar el rendimiento.
+- Para comparar la estrategia con un DCA en distintos ciclos ejecuta:
+  ```bash
+  python -m backtests.multi_period_backtest_runner --csv resultados.csv
+  ```
+  El CSV generado en `results/` incluye columnas como `tipo`, `señales_disparadas`, `fecha_ultima_compra` y `ventaja_pct_vs_dca`.
+- Los gráficos de cada backtest se guardan en `results/` y pueden consultarse para interpretar el rendimiento.
+- Consulta `docs/monthly_backtest_guide.md` para una explicación detallada de cada campo y opciones adicionales.
 
 ## API REST y Frontend
 

--- a/backtests/multi_period_backtest_runner.py
+++ b/backtests/multi_period_backtest_runner.py
@@ -116,7 +116,7 @@ def run_period(
         "retorno_btc_pct": result["btc_return"],
         "retorno_usd_pct": result["usd_return"],
         "ventaja_pct_vs_dca": (
-            ((result["btc_accumulated"] / dca_btc) - 1) * 100 if dca_btc > 0 else 0
+            ((result["final_usd"] / dca_usd) - 1) * 100 if dca_usd > 0 else 0
         ),
         "señales_disparadas": strat_row["señales_disparadas"],
         "fecha_ultima_compra": strat_row["fecha_ultima_compra"],
@@ -188,6 +188,28 @@ def main() -> None:
     table = pd.DataFrame(rows)
     if not table.empty:
         print(table.to_string(index=False))
+
+        strat_rows = table[table["tipo"] == "estrategia"]
+        dca_rows = table[table["tipo"] == "dca"]
+        resumen_rows = table[table["tipo"] == "resumen"]
+
+        mean_usd_strat = strat_rows["retorno_usd_pct"].mean()
+        mean_usd_dca = dca_rows["retorno_usd_pct"].mean()
+        mean_btc_strat = strat_rows["retorno_btc_pct"].mean()
+        win_pct = (
+            (resumen_rows["ventaja_pct_vs_dca"] > 0).sum() / len(resumen_rows) * 100
+            if not resumen_rows.empty
+            else 0
+        )
+        total_signals = int(strat_rows["señales_disparadas"].sum())
+
+        print("\n--- Resumen global ---")
+        print(f"Promedio retorno USD estrategia: {mean_usd_strat:.2f}%")
+        print(f"Promedio retorno USD DCA: {mean_usd_dca:.2f}%")
+        print(f"Promedio retorno BTC estrategia: {mean_btc_strat:.2f}%")
+        print(f"Porcentaje de ciclos con ventaja: {win_pct:.1f}%")
+        print(f"Total de señales disparadas: {total_signals}")
+
         if args.csv:
             csv_path = Path("results") / args.csv
             os.makedirs(csv_path.parent, exist_ok=True)

--- a/docs/monthly_backtest_guide.md
+++ b/docs/monthly_backtest_guide.md
@@ -57,3 +57,18 @@ El archivo se guardará automáticamente en la carpeta `results/` como
 `results/resultados.csv`.
 
 Si no indicas periodos, se probarán cinco rangos predefinidos que cubren distintos ciclos de mercado. Puedes personalizar los periodos pasando pares de fechas (`inicio fin`) al argumento `--periods`.
+
+### Columnas del CSV
+
+Cada periodo genera tres filas: una para la estrategia, otra para el DCA de referencia y una fila de `resumen` que compara ambas. Las columnas son:
+
+- `periodo` y `ciclo`: rango analizado y tipo de mercado.
+- `tipo`: `estrategia`, `dca` o `resumen`.
+- `usd_invertido`: capital acumulado invertido hasta ese periodo.
+- `btc_final` y `usd_final`: saldos obtenidos al final.
+- `retorno_btc_pct` y `retorno_usd_pct`: rendimiento porcentual respecto al capital invertido.
+- `señales_disparadas`: cantidad de compras ejecutadas por la estrategia.
+- `fecha_ultima_compra`: última fecha en que se realizó una operación.
+- `ventaja_pct_vs_dca`: diferencia de rendimiento en USD de la estrategia contra el DCA.
+
+Al final del reporte se imprime un **Resumen global** con promedios de retornos, porcentaje de ciclos donde la estrategia supera al DCA y el total de señales disparadas.


### PR DESCRIPTION
## Summary
- corrige `ventaja_pct_vs_dca` usando el valor final en USD de cada método
- muestra un resumen global con métricas promedio del backtest múltiple
- documenta nuevas columnas y uso del script

## Testing
- `pre-commit run --files backtests/multi_period_backtest_runner.py README.md docs/monthly_backtest_guide.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848b5b26b54832b80b02cc24770d788