### PR TITLE
Add risk metrics and sensitivity analysis to backtester

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ Estrategia de acumulación de Bitcoin que utiliza indicadores técnicos para ide
   ```bash
   python -m backtests.multi_period_backtest_runner --csv resultados.csv
   ```
-  El CSV generado en `results/` incluye columnas como `tipo`, `señales_disparadas`, `fecha_ultima_compra` y `ventaja_pct_vs_dca`.
-- Los gráficos de cada backtest se guardan en `results/` y pueden consultarse para interpretar el rendimiento.
-- Consulta `docs/monthly_backtest_guide.md` para una explicación detallada de cada campo y opciones adicionales.
+  El CSV generado en `results/` incluye columnas de riesgo como `max_drawdown`, `tiempo_en_perdida_pct` y `sharpe_ratio`.
+- Usa `--sensitivity` para evaluar distintas combinaciones de RSI y Bollinger y `--plot` para guardar un gráfico comparativo.
+- Los gráficos de cada backtest se guardan en `results/`; consulta `docs/monthly_backtest_guide.md` para más detalles y ejemplos.
 
 ## API REST y Frontend
 

--- a/backtests/monthly_injection_runner.py
+++ b/backtests/monthly_injection_runner.py
@@ -85,6 +85,18 @@ class MonthlyInjectionBacktest(BTCAccumulationBacktest):
             equity_curve["total_equity"] - equity_curve["peak"]
         ) / equity_curve["peak"]
         max_drawdown = equity_curve["drawdown"].min() * 100
+        time_in_loss = (equity_curve["drawdown"] < 0).mean() * 100
+        monthly_returns = (
+            equity_curve.resample("M", on="date")["total_equity"]
+            .last()
+            .pct_change()
+            .dropna()
+        )
+        sharpe_ratio = (
+            (monthly_returns.mean() / monthly_returns.std()) * (12**0.5)
+            if not monthly_returns.empty
+            else 0.0
+        )
         return {
             "initial_usd": self.initial_usd,
             "final_usd": total_equity,
@@ -92,6 +104,8 @@ class MonthlyInjectionBacktest(BTCAccumulationBacktest):
             "usd_return": usd_return,
             "btc_return": btc_return,
             "max_drawdown": abs(max_drawdown),
+            "time_in_loss_pct": time_in_loss,
+            "sharpe_ratio": sharpe_ratio,
             "trades": self.trades,
             "last_purchase": self.trades[-1]["date"] if self.trades else None,
             "signals_triggered": len(self.trades),

--- a/docs/monthly_backtest_guide.md
+++ b/docs/monthly_backtest_guide.md
@@ -58,6 +58,8 @@ El archivo se guardará automáticamente en la carpeta `results/` como
 
 Si no indicas periodos, se probarán cinco rangos predefinidos que cubren distintos ciclos de mercado. Puedes personalizar los periodos pasando pares de fechas (`inicio fin`) al argumento `--periods`.
 
+Para explorar la sensibilidad de la estrategia también puedes ejecutar con `--sensitivity`, lo que calcula el retorno promedio y la ventaja frente al DCA variando el RSI (25,30,35) y el umbral de Bollinger (0.05,0.08,0.10). Si añades `--plot` se guardará un gráfico comparando cada ciclo.
+
 ### Columnas del CSV
 
 Cada periodo genera tres filas: una para la estrategia, otra para el DCA de referencia y una fila de `resumen` que compara ambas. Las columnas son:
@@ -67,6 +69,9 @@ Cada periodo genera tres filas: una para la estrategia, otra para el DCA de refe
 - `usd_invertido`: capital acumulado invertido hasta ese periodo.
 - `btc_final` y `usd_final`: saldos obtenidos al final.
 - `retorno_btc_pct` y `retorno_usd_pct`: rendimiento porcentual respecto al capital invertido.
+- `max_drawdown`: peor caída porcentual del valor total durante el periodo.
+- `tiempo_en_perdida_pct`: porcentaje de días en que el valor estuvo por debajo del capital invertido.
+- `sharpe_ratio`: relación retorno/volatilidad mensual (aproximada).
 - `señales_disparadas`: cantidad de compras ejecutadas por la estrategia.
 - `fecha_ultima_compra`: última fecha en que se realizó una operación.
 - `ventaja_pct_vs_dca`: diferencia de rendimiento en USD de la estrategia contra el DCA.


### PR DESCRIPTION
## Summary
- extend `MonthlyInjectionBacktest` with drawdown, time in loss and sharpe ratio
- add helper to compute DCA metrics and update default periods
- allow sensitivity analysis and plotting in `multi_period_backtest_runner`
- document new columns and options

## Testing
- `pre-commit run --files README.md docs/monthly_backtest_guide.md backtests/multi_period_backtest_runner.py backtests/monthly_injection_runner.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ba0b28f4832b8ecefde53c297aa8