### PR TITLE
Add onchain csv option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,9 @@ Estrategia de acumulación de Bitcoin que utiliza indicadores técnicos para ide
   alcistas o bajistas, mientras que `--fixed` se usa cuando el mercado es neutral.
   El filtro de RSI se puede desactivar pasando `--rsi-threshold 0`.
   Con `--use-onchain` se añaden las métricas de Glassnode (`sopr` y
-  `exchange_net_flow`) para clasificar el entorno. Puedes indicar archivos
-  descargados con las variables `EXCHANGE_NET_FLOW_CSV` y `SOPR_CSV`.
+  `exchange_net_flow`) para clasificar el entorno. Puedes indicar un CSV
+  alternativo con `--onchain-csv ruta/al/archivo.csv` o usar las variables
+  `EXCHANGE_NET_FLOW_CSV` y `SOPR_CSV`.
 
 ## API REST y Frontend
 

--- a/docs/monthly_backtest_guide.md
+++ b/docs/monthly_backtest_guide.md
@@ -102,6 +102,7 @@ entorno neutral se aplica el monto indicado en `--fixed`.
 - `--rsi-threshold`: nivel mínimo del RSI(45) para activar la compra adaptativa (0 lo desactiva).
 - `--env-threshold`: margen sobre la SMA200 que define bull o bear.
 - `--use-onchain`: fusiona las métricas de Glassnode para detectar el entorno.
+- `--onchain-csv`: ruta al CSV local con `sopr` y `exchange_net_flow`.
 
 ### Columnas extra del CSV
 
@@ -118,7 +119,7 @@ entorno neutral se aplica el monto indicado en `--fixed`.
 python -m backtests.hybrid_trend_backtest_runner \
     --base 100 --factor-bull 200 --factor-bear 150 --fixed 50 \
     --start-date 2018-01-01 --end-date 2021-12-31 \
-    --use-onchain
+    --use-onchain --onchain-csv data/onchain_metrics.csv
 ```
 Si no se cuenta con la clave de Glassnode, define `EXCHANGE_NET_FLOW_CSV` y
-`SOPR_CSV` con las rutas a los CSV descargados manualmente.
+`SOPR_CSV` o usa `--onchain-csv` para indicar un archivo local.


### PR DESCRIPTION
## Summary
- allow custom `--onchain-csv` in `hybrid_trend_backtest_runner`
- document option in README and monthly backtest guide

## Testing
- `pre-commit run --files backtests/hybrid_trend_backtest_runner.py README.md docs/monthly_backtest_guide.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848f48d6610832b965037ffa62d6aa6